### PR TITLE
Fix package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https: //github.com/andreasjhagen/jsdom-worker"
+    "url": "https://github.com/andreasjhagen/jsdom-worker"
   },
   "name": "jsdom-worker-fix",
   "version": "0.1.7",


### PR DESCRIPTION
Unnecessary space there makes it hard to get to this repo from https://www.npmjs.com/package/jsdom-worker-fix